### PR TITLE
Change build to freedesktop runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build-dir/
+build/
 .flatpak-builder/
 repo/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules.git"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -6,28 +6,12 @@ Not all use cases have been tested. If you find something that isn't working, pl
 The best email app for people and teams at work. This repository allows installing Mailspring through Flatpak.
 
 ## Building
-Building the package locally is the only way to install it for now.
-
-Make sure you have flathub enabled:
-```bash
-flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-```
-
-Install the required runtimes:
-```bash
-flatpak install --user flathub org.gnome.Platform//40 \
- org.gnome.Sdk//40 \
- org.electronjs.Electron2.BaseApp//20.08 \
- org.flatpak.Builder
-```
-
-Run the build script:
+Building the package locally is the only way to install the flatpak for now. Just run the `build.sh` script:
 ```bash
 ./build.sh #you may need to enter your password in order to set up the local remote.
 ```
 
-Install and run:
+Then start the app:
 ```bash
-flatpak install --user mailspring-test com.foundry376.Mailspring
 flatpak run com.foundry376.Mailspring
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
-flatpak run org.flatpak.Builder --force-clean --repo=repo build-dir com.foundry376.Mailspring.json &&
-flatpak remote-add --user --if-not-exists --no-gpg-verify mailspring-test repo
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo &&
+flatpak install --user --noninteractive flathub org.flatpak.Builder &&
+flatpak run org.flatpak.Builder --user --install-deps-from=flathub --force-clean --repo=repo build com.foundry376.Mailspring.json &&
+flatpak remote-add --user --if-not-exists --no-gpg-verify --no-enumerate mailspring-test repo &&
+flatpak install --user --noninteractive mailspring-test com.foundry376.Mailspring &&
+exit 0

--- a/com.foundry376.Mailspring.json
+++ b/com.foundry376.Mailspring.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.foundry376.Mailspring",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "20.08",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
-    "sdk": "org.gnome.Sdk",
+    "base-version": "21.08",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "21.08",
+    "sdk": "org.freedesktop.Sdk",
     "command": "mailspring",
     "separate-locales": false,
     "finish-args": [
@@ -23,6 +23,7 @@
         "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
+        "shared-modules/libsecret/libsecret.json",
         {
             "name": "mailspring",
             "buildsystem": "simple",


### PR DESCRIPTION
Build libsecret from shared-modules, instead of using the one built-in on the GNOME SDK, and change the build to use the freedesktop runtime.